### PR TITLE
Use mtime if kMDItemDateAdded is "(null)"

### DIFF
--- a/recent_downloads.rb
+++ b/recent_downloads.rb
@@ -12,7 +12,11 @@ DIR = File.expand_path "~/Downloads"
 Dir.chdir DIR
 def time_added(entry)
   time = `mdls -name kMDItemDateAdded -raw "#{entry}"`
-  Time.parse time
+  if time == "(null)"
+    return File.mtime entry
+  else
+    return Time.parse time
+  end
 end
 
 def get_entries(dir, max_depth)


### PR DESCRIPTION
On a machine updated from Snow Leopard to Lion to Mountain Lion I have
several files in ~/Downloads that don't have a kMDItemDateAdded
attribute.  In that case `mdls` will return "(null)", and in Ruby
Time.parse("(null)") returns the current date/time, not some distant
time in the past, like the epoch.  This means all these ancient files
are sorted to the top.

I think using the modification time is a good fallback for this case,
even though the mtime is not updated for the download but reflects the
original file's modification time.  For all practical purposes these
dates will be earlier than the earliest dates of files that do have a
kMDItemDateAdded attribute, so they will all sort close to the bottom
anyways, which is the main point of this change.

See also http://apple.stackexchange.com/questions/40941/how-do-so-set-date
