### PR TITLE
Only write to config when changes are made

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -29,11 +29,12 @@ module RDW
       @base_dir = File.expand_path "~/Downloads"
       @config = {}
       @config = File.open(@config_file_path, "r") {|f| YAML.load f} if File.exist? @config_file_path
+      original_config = @config.dup
       @config['install_action'] ||= 'open'
       @config['auto_start']     ||= 'never'
       @config['subfolders']     ||= :none
       @config['max-entries']    ||= 20
-      self.commit
+      self.commit unless @config == original_config
       self.standardize
     end
 


### PR DESCRIPTION
config.yaml is being written to every time the workflow runs, even if
no changes were made to it. Since the cache is invalidated every time
the config file changes, this results in slow performance for people
with many downloaded files.
