### PR TITLE
Fix download items when file size can't be detected

### DIFF
--- a/recent_downloads.rb
+++ b/recent_downloads.rb
@@ -85,8 +85,8 @@ if results.length > 0
   results = results.first($config['max-entries']) if $config['max-entries'] != :all
   results.each do |path|
     fullpath = File.expand_path path
-    if path[path.length - 9, 9] == '.download'
-      feedback.add_item(download_item(fullpath))
+    if path[path.length - 9, 9] == '.download' && dl_item = download_item(fullpath)
+      feedback.add_item(dl_item)
     else
       feedback.add_item({:title => File.basename(path), :subtitle => path, :arg => fullpath,
                           :icon => {:type => "fileicon", :name => fullpath}})


### PR DESCRIPTION
Fixes an error that causes no results to show when Safari can't
detect the total file size of a download. Also added some really basic
error catching so it displays a generic file result if we get an
unexpected error during the download detection.
