### PR TITLE
Explicit defining of encoding

### DIFF
--- a/recent_downloads.rb
+++ b/recent_downloads.rb
@@ -5,6 +5,9 @@ load "alfred_feedback.rb"
 load "config.rb"
 load "download_progress.rb"
 
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 $config = RDW::Config.new
 
 Data_File = File.expand_path "recent_downloads.txt", RDW::Config::VOLATILE_DIR


### PR DESCRIPTION
At some moment (probably after updating to OS X 10.9) workflow stoped working. Some investigation showed problem with encoding. As @wwwjfy suggested in https://github.com/ddjfreedom/recent-downloads-alfred-v2/issues/12 I've added explicit defining of encoding into `recent_downloads.rb` and it actually helped.
