### PR TITLE
Handle files without read permission

### DIFF
--- a/recent_downloads.rb
+++ b/recent_downloads.rb
@@ -59,7 +59,7 @@ if entries.length > 0
   time_values = `mdls -name kMDItemDateAdded -raw #{escaped_entries.join(' ')}`.split("\0")
 
   entries = entries.each_with_index.map do |entry, i|
-    if time_values[i] == "(null)"
+    if time_values[i] == "(null)" || time_values[i].nil?
       time = File.mtime entry
     else
       time = Time.parse time_values[i]


### PR DESCRIPTION
mdls reports 'No such file or directory', which results in a nil timestamp that has to be handled.

As #11 and #16 are both not merged for a while and I needed them to make this workflow work, I created a fork with a `fixes` branch integrating both of them and this change: https://github.com/meeee/recent-downloads-alfred-v2
